### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ container in which OpenCog will be built and run.
 ###### cxxtest
 > Test framework
 > http://cxxtest.sourceforge.net/ | https://launchpad.net/~opencog-dev/+archive/ppa
-> Currently, opencog requires cxxtest version 3, and is not compatible
-  with version 4.
 
 Optional Prerequisites
 ----------------------


### PR DESCRIPTION
Removed the following line as it is outdated and indeed works with version 4:
"Currently, opencog requires cxxtest version 3, and is not compatible with version 4."
